### PR TITLE
Add stddev output

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -81,3 +81,11 @@ fn main() {
         sleep(Duration::new(1, 0));
     }
 }
+
+#[test]
+fn test_stddev() {
+    let data = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+    assert_eq!(mean(&data), 5.0);
+    assert_eq!(variance(&data), 11.0);
+    assert_eq!(stddev(&data), 11.0_f32.sqrt());
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,24 +7,43 @@ use std::env;
 use std::thread::sleep;
 use std::time::{Duration, Instant};
 
+fn mean(v: &[u128]) -> f32 {
+    let sum = v.iter().sum::<u128>() as f32;
+    let count = v.len();
+    let mean = sum / count as f32;
+    mean
+}
+
+fn variance(v: &[u128]) -> f32 {
+    let mean = mean(v);
+    let variance = v
+        .iter()
+        .map(|current| (*current as f32 - mean).powi(2))
+        .sum::<f32>() as f32
+        / (v.len() - 1) as f32;
+    variance
+}
+
+fn stddev(v: &[u128]) -> f32 {
+    variance(v).sqrt()
+}
+
 fn open_ssh_connection(hostname: &str) -> PtySession {
     let cmd = format!("ssh -t {}", hostname);
-    let mut p = spawn(&cmd, Some(30000))
-        .unwrap_or_else(|e| panic!("Failed to launch ssh: {}", e));
+    let mut p = spawn(&cmd, Some(30000)).unwrap_or_else(|e| panic!("Failed to launch ssh: {}", e));
     println!("ssh opened. (Touching security key may be needed.)");
     p.exp_regex(r"\$|#").unwrap();
     println!("prompt found");
     p
 }
 
-fn ping_and_increment_seq(ssh: &mut PtySession, seq: &mut usize) -> Duration {
+fn ping_and_increment_seq(ssh: &mut PtySession, seq: &usize) -> Duration {
     let now = Instant::now();
     let cmd = format!("echo \"hello\" {}", seq);
     let expected = format!("hello {}", seq);
     ssh.send_line(&cmd).unwrap();
     ssh.exp_regex(&expected).unwrap();
     let elapsed = now.elapsed();
-    *seq += 1;
     elapsed
 }
 
@@ -36,21 +55,28 @@ fn main() {
     }
     let host = &args[1];
     let mut ssh = open_ssh_connection(&host);
-    let mut seq = 0;
 
-    let mut avg = 0;
     let mut max = 0;
     let mut min = std::u128::MAX;
+    let mut elapsed_times_ms: Vec<u128> = vec![];
 
     loop {
-        let elapsed = ping_and_increment_seq(&mut ssh, &mut seq);
+        let elapsed = ping_and_increment_seq(&mut ssh, &elapsed_times_ms.len());
         let elapsed_ms = elapsed.as_millis();
-        avg = (avg * (seq - 1) as u128 + elapsed_ms) / seq as u128;
+        elapsed_times_ms.push(elapsed_ms);
+
+        let mean = mean(&elapsed_times_ms);
+        let stddev = stddev(&elapsed_times_ms);
         max = cmp::max(max, elapsed_ms);
         min = cmp::min(min, elapsed_ms);
         println!(
-            "{:?} avg: {}, min: {}, max: {}, count: {}",
-            elapsed, avg, min, max, seq
+            "{:?} mean: {}, sd: {}, min: {}, max: {}, count: {}",
+            elapsed,
+            mean,
+            stddev,
+            min,
+            max,
+            elapsed_times_ms.len()
         );
         sleep(Duration::new(1, 0));
     }


### PR DESCRIPTION
Add some notion of variance.


$ cargo run sakura2
    Finished dev [unoptimized + debuginfo] target(s) in 0.01s
     Running `/home/dancer/git/nlp-study/third_party/ssh_latency/target/debug/ssh_latency sakura2`
ssh opened. (Touching security key may be needed.)
prompt found
17.271541ms mean: 17, sd: NaN, min: 17, max: 17, count: 1
17.74199ms mean: 17, sd: 0, min: 17, max: 17, count: 2
20.900689ms mean: 18, sd: 1.7320508, min: 17, max: 20, count: 3
18.194071ms mean: 18, sd: 1.4142135, min: 17, max: 20, count: 4
17.704206ms mean: 17.8, sd: 1.3038405, min: 17, max: 20, count: 5
17.919526ms mean: 17.666666, sd: 1.2110602, min: 17, max: 20, count: 6
17.647984ms mean: 17.571428, sd: 1.1338935, min: 17, max: 20, count: 7
18.009831ms mean: 17.625, sd: 1.0606601, min: 17, max: 20, count: 8
17.967577ms mean: 17.555555, sd: 1.0137938, min: 17, max: 20, count: 9
18.117874ms mean: 17.6, sd: 0.9660918, min: 17, max: 20, count: 10
18.057183ms mean: 17.636364, sd: 0.92441624, min: 17, max: 20, count: 11
18.162782ms mean: 17.666666, sd: 0.88762546, min: 17, max: 20, count: 12
17.754911ms mean: 17.615385, sd: 0.86971843, min: 17, max: 20, count: 13
